### PR TITLE
change github links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "webapp to show deaths on the current day in the past 10 years",
   "main": "index.js",
   "scripts": {
+    "start": "node src/server.js",
     "test": "tape tests/*.js | faucet",
     "coverage": "istanbul cover tests/*.js"
   },

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FAC10/week5-zapo.git"
+    "url": "git+https://github.com/oliverjam/week5-zapo"
   },
   "author": "zapo",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/FAC10/week5-zapo/issues"
+    "url": "https://github.com/oliverjam/week5-zapo/issues"
   },
-  "homepage": "https://github.com/FAC10/week5-zapo#readme",
+  "homepage": "https://github.com/oliverjam/week5-zapo#readme",
   "devDependencies": {
     "codecov": "^2.1.0",
     "eslint": "^3.18.0",


### PR DESCRIPTION
We've moved our repo away from the fac10 organisation as the queue from all the projectso n travis was taking way too much time, so I've changed the urls in our package.json so they properly reflect our remote
relates to #5