### PR TITLE
Clean up getObits

### DIFF
--- a/src/getObits.js
+++ b/src/getObits.js
@@ -1,22 +1,26 @@
 require('env2')('.env');
-var createDates = require('./createDates');
+const createDates = require('./createDates');
 
 const request = require('request');
 
-let resultsArr = [];
+const resultsArr = [];
 
 function requests(datesArr, cb) {
-    datesArr.forEach((date => {
-            let url = `https://content.guardianapis.com/search?tag=tone/obituaries&from-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
-            request(url, (err, res, body) => {
-              let title = res.results[0].webTitle;
-              let url = res.results[0].webUrl;
-              let summary = res.results[0].fields.trailText;
-              const obj = {title, url, summary};
-              resultsArr.push(obj);
-              if(resultsArr.length === datesArr.length) {
-                cb(resultsArr);
-              }
-            });
-        })
-    }
+  datesArr.forEach((date) => {
+    const url = `https://content.guardianapis.com/search?tag=tone/obituaries&from-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
+    request(url, (err, res, body) => {
+      const title = res.results[0].webTitle;
+      const url = res.results[0].webUrl;
+      const summary = res.results[0].fields.trailText;
+      const obj = {
+        title,
+        url,
+        summary,
+      };
+      resultsArr.push(obj);
+      if (resultsArr.length === datesArr.length) {
+        cb(resultsArr);
+      }
+    });
+  });
+}

--- a/src/getObits.js
+++ b/src/getObits.js
@@ -3,7 +3,7 @@ const createDates = require('./createDates');
 
 const request = require('request');
 
-function requests(datesArr, cb) {
+function getObits(datesArr, cb) {
   const resultsArr = [];
   datesArr.forEach((date) => {
     const url = `https://content.guardianapis.com/search?tag=tone/obituaries&from-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
@@ -20,3 +20,5 @@ function requests(datesArr, cb) {
     });
   });
 }
+
+module.exports = getObits;

--- a/src/getObits.js
+++ b/src/getObits.js
@@ -3,9 +3,8 @@ const createDates = require('./createDates');
 
 const request = require('request');
 
-const resultsArr = [];
-
 function requests(datesArr, cb) {
+  const resultsArr = [];
   datesArr.forEach((date) => {
     const url = `https://content.guardianapis.com/search?tag=tone/obituaries&from-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
     request(url, (err, res, body) => {

--- a/src/getObits.js
+++ b/src/getObits.js
@@ -9,13 +9,10 @@ function requests(datesArr, cb) {
   datesArr.forEach((date) => {
     const url = `https://content.guardianapis.com/search?tag=tone/obituaries&from-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
     request(url, (err, res, body) => {
-      const title = res.results[0].webTitle;
-      const url = res.results[0].webUrl;
-      const summary = res.results[0].fields.trailText;
       const obj = {
-        title,
-        url,
-        summary,
+        title: res.results[0].webTitle,
+        url: res.results[0].webUrl,
+        summary: res.results[0].fields.trailText,
       };
       resultsArr.push(obj);
       if (resultsArr.length === datesArr.length) {

--- a/src/getObits.js
+++ b/src/getObits.js
@@ -8,10 +8,12 @@ function getObits(datesArr, cb) {
   datesArr.forEach((date) => {
     const url = `https://content.guardianapis.com/search?tag=tone/obituaries&from-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
     request(url, (err, res, body) => {
+      // I thought Request provided JSON automatically but apparently not
+      const data = JSON.parse(body).response;
       const obj = {
-        title: res.results[0].webTitle,
-        url: res.results[0].webUrl,
-        summary: res.results[0].fields.trailText,
+        title: data.results[0].webTitle,
+        url: data.results[0].webUrl,
+        summary: data.results[0].fields.trailText,
       };
       resultsArr.push(obj);
       if (resultsArr.length === datesArr.length) {

--- a/src/getObits.js
+++ b/src/getObits.js
@@ -6,7 +6,7 @@ const request = require('request');
 function getObits(datesArr, cb) {
   const resultsArr = [];
   datesArr.forEach((date) => {
-    const url = `https://content.guardianapis.com/search?tag=tone/obituaries&from-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
+    const url = `https://content.guardianapis.com/search?tag=tone/obituaries&to-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
     request(url, (err, res, body) => {
       // I thought Request provided JSON automatically but apparently not
       const data = JSON.parse(body).response;


### PR DESCRIPTION
There were some linter/parser errors in this function so I cleaned them up (there were a couple of brackets missing).

I ran some tests using `request` and found that we actually need to use the `body` parameter to get the API data. We were using `res`, which gives you a shit-ton of stuff we don't need (except maybe the `statusCode`.

Also for some reason we need to `JSON.parse()` it, even though `request` is supposed to do that for you if the API provides JSON.

Also also I changed the URL to use `todate` instead of `fromdate`. Previously we were getting all the obituaries from the date till now, so we ended up with an array of just whatever was most recently posted.

Relates #13 