### PR TITLE
Remove bad tags

### DIFF
--- a/src/extractData.js
+++ b/src/extractData.js
@@ -8,7 +8,7 @@ function extractData(body) {
   return {
     title: body.response.results[0].webTitle,
     url: body.response.results[0].webUrl,
-    summary: body.response.results[0].fields.trailText,
+    summary: body.response.results[0].fields.trailText.replace(/<(?:.|\n)*?>/gm, ''),
   };
 }
 

--- a/src/handlers/handler.js
+++ b/src/handlers/handler.js
@@ -33,6 +33,7 @@ handlers.servePublic = (request, response, url) => {
         js: 'application/javascript',
         ico: 'image/x-icon',
         png: 'image/png',
+        svg: 'image/svg+xml',
       };
       response.writeHead(200, { 'Content-Type': extensionType[extension] });
       response.end(file);

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -5,7 +5,7 @@ module.exports = function (request, response) {
   const extension = url.split('.')[1];
   if (url === '/') {
     handlers.serveLanding(request, response);
-  } else if (extension === 'css' || extension === 'js' || extension === 'html' || extension === 'ico' || extension === 'png') {
+  } else if (extension === 'css' || extension === 'js' || extension === 'html' || extension === 'ico' || extension === 'png' || extension === 'svg') {
     handlers.servePublic(request, response, url);
   } else if (url.indexOf('/api') !== -1) { // TBC
     handlers.serveAPI(request, response);

--- a/tests/extractData.test.js
+++ b/tests/extractData.test.js
@@ -33,7 +33,7 @@ const extractDataTests = () => {
     const expected = {
       title: 'Diana Wallace obituary',
       url: 'https://www.theguardian.com/education/2017/mar/22/diana-wallace-obituary',
-      summary: '<strong>Other lives: </strong>Social worker who was guided by her Christian faith',
+      summary: 'Other lives: Social worker who was guided by her Christian faith',
     };
     const actual = extractData(fakeBody);
     t.ok(typeof actual === 'object', 'Should return an object');


### PR DESCRIPTION
Added some sneaky clever regex to get rid of html tags:
`.replace(/<(?:.|\n)*?>/gm, '')`