### PR TITLE
Ask Request for JSON so we don't have to parse

### DIFF
--- a/src/getObits.js
+++ b/src/getObits.js
@@ -7,12 +7,11 @@ function getObits(datesArr, cb) {
   const resultsArr = [];
   datesArr.forEach((date) => {
     const url = `https://content.guardianapis.com/search?tag=tone/obituaries&to-date=${date}&order-by=newest&api-key=${process.env.SECRET}&show-fields=trailText`;
-    request(url, (err, res, body) => {
+    request({ url, json: true }, (err, res, body) => {
       if (err) {
         cb(err);
       }
-      // I thought Request provided JSON automatically but apparently not
-      const data = extractData(JSON.parse(body));
+      const data = extractData(body);
       resultsArr.push(data);
       if (resultsArr.length === datesArr.length) {
         cb(null, resultsArr);


### PR DESCRIPTION
We can pass `json: true` as an option for Request, so it pre-formats the data for us.

Relates #46