### PR TITLE
Remove nodemon as we aren't using it

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "webapp to show deaths on the current day in the past 10 years",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon src/server.js",
+    "start": "node src/server.js",
     "test": "tape tests/test.js | tap-spec",
     "coverage": "istanbul cover tests/test.js"
   },
@@ -23,7 +23,6 @@
     "eslint": "^3.18.0",
     "eslint-config-airbnb": "^14.1.0",
     "istanbul": "^0.4.5",
-    "nodemon": "^1.11.0",
     "shot": "^3.4.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.3"


### PR DESCRIPTION
Heroku crashed because I changed `npm start` to use Nodemon, which isn't a dependency. This removes Nodemon entirely as we don't really need it.

Relates #53 